### PR TITLE
Fix reverse engineered chatgpt not working

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1848,14 +1848,14 @@ requests = ">=2.0.1,<3.0.0"
 
 [[package]]
 name = "revchatgpt"
-version = "3.2.0"
+version = "3.3.1"
 description = "ChatGPT is a reverse engineering of OpenAI's ChatGPT API"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "revChatGPT-3.2.0-py3-none-any.whl", hash = "sha256:8410384f3d9407a0ad29f934a05c574eadba27f87194ff4819649fc1b4195f74"},
-    {file = "revChatGPT-3.2.0.tar.gz", hash = "sha256:501d47c2ddceb6da288f2306d6e7a5a7f9a9c5cec9fce224715f312483924f0e"},
+    {file = "revChatGPT-3.3.1-py3-none-any.whl", hash = "sha256:3ca416090f443f055d1bd51d0d6258df6759af03d5025be6ed5a2d7b428a7452"},
+    {file = "revChatGPT-3.3.1.tar.gz", hash = "sha256:0677174ed0bd460d61d8bd70d46f28535973c1db71289df37f1be1a19c4e8269"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ python = "^3.9"
 poetry = "^1.4.0"
 typer = { extras = ["all"], version = "^0.7.0" }
 rich = "<13.0.0"                                 # limited version as 13.0.0 because of typer
-revchatgpt = "^3.2.0"
+revchatgpt = "^3.3.1"
 pydantic = "^1.10.5"
 yt-dlp = "^2023.3.4"
 


### PR DESCRIPTION
## Context
- #11

## Changes
- Fix `ygka` to be workable again, by bumping up `revChatGPT`, which fixes #11 
